### PR TITLE
SI-9617 Handle deprecations from Java correctly

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1128,6 +1128,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BooleanBeanPropertyAttr    = requiredClass[scala.beans.BooleanBeanProperty]
     lazy val CompileTimeOnlyAttr        = getClassIfDefined("scala.annotation.compileTimeOnly")
     lazy val DeprecatedAttr             = requiredClass[scala.deprecated]
+    lazy val JavaDeprecatedAttr         = requiredClass[java.lang.Deprecated]
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1148,7 +1148,6 @@ trait Definitions extends api.StandardDefinitions {
     // Meta-annotations
     lazy val BeanGetterTargetClass      = requiredClass[meta.beanGetter]
     lazy val BeanSetterTargetClass      = requiredClass[meta.beanSetter]
-    lazy val ConstructorTargetClass     = requiredClass[meta.constructor]
     lazy val FieldTargetClass           = requiredClass[meta.field]
     lazy val GetterTargetClass          = requiredClass[meta.getter]
     lazy val ParamTargetClass           = requiredClass[meta.param]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -877,7 +877,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isStrictFP          = hasAnnotation(ScalaStrictFPAttr) || (enclClass hasAnnotation ScalaStrictFPAttr)
     def isSerializable      = info.baseClasses.exists(p => p == SerializableClass || p == JavaSerializableClass)
     def hasBridgeAnnotation = hasAnnotation(BridgeClass)
-    def isDeprecated        = hasAnnotation(DeprecatedAttr)
+    def isDeprecated        = hasAnnotation(DeprecatedAttr) || (isJava && hasAnnotation(JavaDeprecatedAttr))
     def deprecationMessage  = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion  = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
     def deprecatedParamName = getAnnotation(DeprecatedNameAttr) flatMap (_ symbolArg 0 orElse Some(nme.NO_NAME))

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -390,6 +390,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.BooleanBeanPropertyAttr
     definitions.CompileTimeOnlyAttr
     definitions.DeprecatedAttr
+    definitions.JavaDeprecatedAttr
     definitions.DeprecatedNameAttr
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -408,7 +408,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.VolatileAttr
     definitions.BeanGetterTargetClass
     definitions.BeanSetterTargetClass
-    definitions.ConstructorTargetClass
     definitions.FieldTargetClass
     definitions.GetterTargetClass
     definitions.ParamTargetClass

--- a/test/files/run/t9617.check
+++ b/test/files/run/t9617.check
@@ -1,0 +1,13 @@
+newSource1.scala:3: warning: method foo in object J is deprecated
+  J.foo()
+    ^
+newSource1.scala:4: warning: variable i in object J is deprecated
+  J.bar(J.i)
+          ^
+newSource1.scala:5: warning: constructor J in class J is deprecated
+  val j = new J()
+          ^
+newSource1.scala:6: warning: class JInner in class J is deprecated
+  val inner = new j.JInner()
+                    ^
+error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/run/t9617.scala
+++ b/test/files/run/t9617.scala
@@ -1,0 +1,55 @@
+import scala.tools.partest.DirectTest
+
+/**
+ * Tests that when building a mixed Java/Scala project, where Scala code uses deprecated methods from Java file
+ * and Java files are not yet built using javac, deprecation warnings are properly reported.
+ *
+ * The test is written in such a form as when having a directory with both files in neg directory,
+ * Java sources are built and the problem is not properly reproduced.
+ */
+object Test extends DirectTest {
+
+  val javaCode =
+    """
+      |public class J {
+      |
+      |  @Deprecated
+      |  public static int i = 0;
+      |
+      |  @Deprecated public class JInner {}
+      |
+      |  @Deprecated
+      |  public J() {}
+      |
+      |  @Deprecated
+      |  public static void foo() {}
+      |
+      |  // @Deprecated used with a parameter has no effect
+      |  public static void bar(@Deprecated int i) {}
+      |}
+    """.stripMargin
+
+  val scalaCode =
+    """
+      |class S {
+      |  J.foo()
+      |  J.bar(J.i)
+      |  val j = new J()
+      |  val inner = new j.JInner()
+      |}
+    """.stripMargin
+
+  val sources = newJavaSources(javaCode) ++ newSources(scalaCode)
+
+  val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+  val compiler = newCompiler("-cp", classpath, "-deprecation", "-Xfatal-warnings")
+
+  sourceFilesToCompiledUnits(compiler)(sources)
+
+  // It's an abstract member which needs to be implemented but we don't use it at all.
+  def code: String = ???
+
+  // We expect that after the execution there will be messages from compilation
+  // and it's not needed to print here anything else.
+  def show(): Unit = {}
+}

--- a/test/files/run/t9617b.check
+++ b/test/files/run/t9617b.check
@@ -1,0 +1,4 @@
+newSource1.scala:4: warning: method bar in object J is deprecated
+  J.bar()
+    ^
+error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/run/t9617b.scala
+++ b/test/files/run/t9617b.scala
@@ -1,0 +1,54 @@
+import scala.tools.partest.DirectTest
+
+/**
+ * Tests that when building a mixed Java/Scala project where
+ * - Scala code uses a method from Java which is marked using custom Deprecated annotation
+ * - and Java files are not yet built using javac
+ * there are no deprecation warnings related to this annotation.
+ * On the other hand, fully qualified @java.lang.Deprecated is still handled properly.
+ */
+object Test extends DirectTest {
+
+  val customDeprecation =
+    """
+      |import java.lang.annotation.*;
+      |import static java.lang.annotation.ElementType.*;
+      |
+      |@Documented
+      |@Retention(RetentionPolicy.RUNTIME)
+      |public @interface Deprecated {}
+    """.stripMargin
+
+  val javaCode =
+    """
+      |public class J {
+      |  @Deprecated
+      |  public static void foo() {}
+      |
+      |  @java.lang.Deprecated
+      |  public static void bar() {}
+      |}
+    """.stripMargin
+
+  val scalaCode =
+    """
+      |class S {
+      |  J.foo()
+      |  J.bar()
+      |}
+    """.stripMargin
+
+  val sources = newJavaSources(customDeprecation, javaCode) ++ newSources(scalaCode)
+
+  val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+  val compiler = newCompiler("-cp", classpath, "-deprecation", "-Xfatal-warnings")
+
+  sourceFilesToCompiledUnits(compiler)(sources)
+
+  // It's an abstract member which needs to be implemented but we don't use it at all.
+  def code: String = ???
+
+  // We expect that after the execution there will be messages from compilation
+  // and it's not needed to print here anything else.
+  def show(): Unit = {}
+}


### PR DESCRIPTION
Since it requires the support for annotation to work, I created a small fix on top of this branch (even though the code in it is not finished yet).

I'm not sure whether for you it makes sense to merge it here or I just should follow your PR to scala/scala, wait to have it merged someday and then create PR directly to scala/scala. Anyway it's created mostly FYI.

Even if you'd merge these changes to your branch, certainly the first commit should be squashed with your commit.

And now details of the issue and the content of this PR:

There was problem that deprecations from Java were not taken into account in Scala after parsing Java sources in mixed projects (when they are not yet compiled). Warnings would not be generated.

They would be generated only during the incremental compilation (Java files already compiled using javac). It's esp. problematic in case of -Xfatal-warnings as the CI build may pass, but users would report problems in Scala IDE or IntelliJ.

Since Scala now is able to handle Java annotations, it was possible to just check in Symbols.scala that something defined in Java sources is annotated as deprecated. I also added adequate tests.

Tests pass and there are no new failing tests. Some tests which fail with your original change (together with my small fix in the first commit to have the code compiling) obviously still fail also after introducing changes related to java.lang.Deprecated.